### PR TITLE
Conform `llvm::Twine` to `ExpressibleByStringLiteral`

### DIFF
--- a/Sources/LLVM/LLVM_Utils.swift
+++ b/Sources/LLVM/LLVM_Utils.swift
@@ -28,3 +28,9 @@ extension StaticString {
     }
   }
 }
+
+extension llvm.Twine: ExpressibleByStringLiteral {
+  public init(stringLiteral value: String) {
+    self.init(value)
+  }
+}


### PR DESCRIPTION
Similar to https://github.com/apple/swift/pull/60267.