### PR TITLE
[build] Explicitly tell CMake that the project uses C language

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.18)
 
-project(SwiftLLVMBindings LANGUAGES Swift)
+project(SwiftLLVMBindings LANGUAGES C Swift)
 
 if(CMAKE_SYSTEM_NAME STREQUAL Windows OR CMAKE_SYSTEM_NAME STREQUAL Darwin)
   option(BUILD_SHARED_LIBS "Build shared libraries by default" YES)


### PR DESCRIPTION
This fixes a CMake error:

```
CMake Error at cmake-3.23/Modules/Internal/CheckSourceCompiles.cmake:44 (message):
  check_source_compiles: C: needs to be enabled before use.
Call Stack (most recent call first):
 cmake-3.23/Modules/CheckCSourceCompiles.cmake:76 (cmake_check_source_compiles)
  /Volumes/Projects/swift/build/Ninja-DebugAssert/llvm-macosx-arm64/lib/cmake/llvm/FindTerminfo.cmake:21 (check_c_source_compiles)
  /Volumes/Projects/swift/build/Ninja-DebugAssert/llvm-macosx-arm64/lib/cmake/llvm/LLVMConfig.cmake:186 (find_package)
  CMakeLists.txt:15 (find_package)
```