### PR TITLE
[build] Disable library evolution

### DIFF
--- a/Sources/LLVM/CMakeLists.txt
+++ b/Sources/LLVM/CMakeLists.txt
@@ -1,8 +1,7 @@
 add_library(LLVM_Utils
     LLVM_Utils.swift)
 target_compile_options(LLVM_Utils PUBLIC
-    "-enable-library-evolution"
-    "-emit-module-interface"
+    "-emit-module"
     "-Xfrontend" "-enable-experimental-cxx-interop")
 target_include_directories(LLVM_Utils PUBLIC
     "${LLVM_MAIN_INCLUDE_DIR}"


### PR DESCRIPTION
This project is not designed to be ABI-stable at the moment, so library evolution is not needed.