### PR TITLE
[build] Add CMake target installation mechanism

### DIFF
--- a/Sources/LLVM/CMakeLists.txt
+++ b/Sources/LLVM/CMakeLists.txt
@@ -6,3 +6,6 @@ target_compile_options(LLVM_Utils PUBLIC
 target_include_directories(LLVM_Utils PUBLIC
     "${LLVM_MAIN_INCLUDE_DIR}"
     "${LLVM_INCLUDE_DIR}")
+install(TARGETS LLVM_Utils
+    ARCHIVE DESTINATION lib
+    LIBRARY DESTINATION lib)


### PR DESCRIPTION
This is needed to introduce a dependency on the bindings in SwiftCompilerSources