### PR TITLE
[LLVM] Workaround Swift lookup issue

### DIFF
--- a/Sources/LLVM/LLVM_Utils.swift
+++ b/Sources/LLVM/LLVM_Utils.swift
@@ -12,6 +12,9 @@
 
 @_exported import LLVM_Utils // Clang module
 
+// FIXME: rdar://99146607
+var _anchor: llvm.StringRef { return llvm.StringRef() }
+
 extension String {
   public func withStringRef<Result>(_ body: (llvm.StringRef) -> Result) -> Result {
     var str = self


### PR DESCRIPTION
Currently `String.withStringRef` cannot be used from Swift: trying to use it results in "no such function" errors.

The Swift module interface for `LLVM_Utils` looks like this:
```swift
extension String {
}
extension StaticString {
  func withStringRef<Result>(_ body: (llvm.StringRef) -> Result) -> Result
}
```

The `withStringRef` function is missing from its extension. This is probably a C++ interop bug.