### PR TITLE
[LLVM] Add string equality operator

### DIFF
--- a/Sources/LLVM/LLVM_Utils.swift
+++ b/Sources/LLVM/LLVM_Utils.swift
@@ -29,6 +29,16 @@ extension StaticString {
   }
 }
 
+public func ==(lhs: llvm.StringRef, rhs: StaticString) -> Bool {
+  let lhsBuffer = UnsafeBufferPointer<UInt8>(
+    start: lhs.__bytes_beginUnsafe(),
+    count: Int(lhs.__bytes_endUnsafe() - lhs.__bytes_beginUnsafe()))
+  return rhs.withUTF8Buffer { (rhsBuffer: UnsafeBufferPointer<UInt8>) in
+    if lhsBuffer.count != rhsBuffer.count { return false }
+    return lhsBuffer.elementsEqual(rhsBuffer, by: ==)
+  }
+}
+
 extension llvm.Twine: ExpressibleByStringLiteral {
   public init(stringLiteral value: String) {
     self.init(value)


### PR DESCRIPTION
This allows checking strings for equality, e.g. `llvmString == "some swift string literal"` without an explicit string conversion.

Inspired by a similar operator in SwiftCompilerSources, with a minor difference that this works for raw LLVM `StringRef`s, not for wrapped LLVM `StringRef`s: https://github.com/apple/swift/blob/aea26bbc6e59520c067f2f5dc85b1d9f1cd28d2e/SwiftCompilerSources/Sources/Basic/Utils.swift#L69