### PR TITLE
[LLVM] Add `llvm::StringRef` -> `String` initializer

### DIFF
--- a/Sources/LLVM/LLVM_Utils.swift
+++ b/Sources/LLVM/LLVM_Utils.swift
@@ -13,6 +13,10 @@
 @_exported import LLVM_Utils // Clang module
 
 extension String {
+  public init(_ stringRef: llvm.StringRef) {
+    self.init(cxxString: stringRef.str())
+  }
+
   public func withStringRef<Result>(_ body: (llvm.StringRef) -> Result) -> Result {
     var str = self
     return str.withUTF8 { buffer in


### PR DESCRIPTION
This allows conveniently getting a Swift String from an LLVM StringRef.