### PR TITLE
[build] Use C++17 standard

### DIFF
--- a/Sources/LLVM/CMakeLists.txt
+++ b/Sources/LLVM/CMakeLists.txt
@@ -2,6 +2,7 @@ add_library(LLVM_Utils
     LLVM_Utils.swift)
 target_compile_options(LLVM_Utils PUBLIC
     "-emit-module"
+    "-Xcc" "-std=c++17"
     "-Xfrontend" "-enable-experimental-cxx-interop")
 target_include_directories(LLVM_Utils PUBLIC
     "${LLVM_MAIN_INCLUDE_DIR}"


### PR DESCRIPTION
This tells the Swift compiler to parse LLVM C++ headers in C++17 mode. LLVM codebase requires C++17 since last year, and this change prevents compilation errors when building the bindings.