### PR TITLE
[build] Require Swift 5.9 or newer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL Windows)
   option(BUILD_SHARED_LIBS "Build shared libraries by default" YES)
 endif()
 
-set(min_supported_swift_version 5.8)
+set(min_supported_swift_version 5.9)
 if(CMAKE_Swift_COMPILER_VERSION VERSION_LESS "${min_supported_swift_version}")
   message(FATAL_ERROR "Outdated Swift compiler: "
       "Swift ${min_supported_swift_version} or newer is required.")


### PR DESCRIPTION
We're going to rely on the recent fixes and improvements of C++ interop, so make sure we're running a recent enough compiler.