### PR TITLE
Remove uses of `fatalError` from `Package.swift`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,28 +6,27 @@ import class Foundation.ProcessInfo
 
 let env = ProcessInfo.processInfo.environment
 
-guard let llvmHeaderPath = env["SWIFT_LLVM_BINDINGS_PATH_TO_LLVM_HEADERS"] else {
-  fatalError("please pass an environment variable to swift-package: " +
-               "SWIFT_LLVM_BINDINGS_PATH_TO_LLVM_HEADERS " +
-               "(e.g. swift/llvm-project/llvm/include)")
-}
-let llvmModuleMapPath = "\(llvmHeaderPath)/llvm/module.modulemap"
-guard let llvmGeneratedHeaderPath = env["SWIFT_LLVM_BINDINGS_PATH_TO_LLVM_GENERATED_HEADERS"] else {
-  fatalError("please pass an environment variable to swift-package: " +
-               "SWIFT_LLVM_BINDINGS_PATH_TO_LLVM_GENERATED_HEADERS " +
-               "(e.g. swift/build/Ninja-DebugAssert/llvm-macosx-arm64/include)")
-}
+func getLLVMSwiftSettings() -> [SwiftSetting]? {
+    let env = ProcessInfo.processInfo.environment
+    guard let llvmHeaderPath = env["SWIFT_LLVM_BINDINGS_PATH_TO_LLVM_HEADERS"] else {
+        return nil
+    }
+    let llvmModuleMapPath = "\(llvmHeaderPath)/llvm/module.modulemap"
+    guard let llvmGeneratedHeaderPath = env["SWIFT_LLVM_BINDINGS_PATH_TO_LLVM_GENERATED_HEADERS"] else {
+        return nil
+    }
 
-let llvmSwiftSettings: [SwiftSetting] = [
-  .interoperabilityMode(.Cxx),
-  .unsafeFlags([
-                 "-I\(llvmHeaderPath)",
-                 "-Xcc", "-I\(llvmHeaderPath)",
-                 "-I\(llvmGeneratedHeaderPath)",
-                 "-Xcc", "-I\(llvmGeneratedHeaderPath)",
-                 "-Xcc", "-fmodule-map-file=\(llvmModuleMapPath)",
-               ]),
-]
+    return [
+        .interoperabilityMode(.Cxx),
+        .unsafeFlags([
+             "-I\(llvmHeaderPath)",
+             "-Xcc", "-I\(llvmHeaderPath)",
+             "-I\(llvmGeneratedHeaderPath)",
+             "-Xcc", "-I\(llvmGeneratedHeaderPath)",
+             "-Xcc", "-fmodule-map-file=\(llvmModuleMapPath)",
+        ]),
+    ]
+}
 
 let package = Package(
   name: "SwiftLLVMBindings",
@@ -40,7 +39,7 @@ let package = Package(
       path: "Sources/LLVM",
       exclude: ["CMakeLists.txt"],
       sources: ["LLVM_Utils.swift"],
-      swiftSettings: llvmSwiftSettings
+      swiftSettings: getLLVMSwiftSettings()
     ),
   ],
   cxxLanguageStandard: .cxx17

--- a/Package.swift
+++ b/Package.swift
@@ -9,10 +9,16 @@ let env = ProcessInfo.processInfo.environment
 func getLLVMSwiftSettings() -> [SwiftSetting]? {
     let env = ProcessInfo.processInfo.environment
     guard let llvmHeaderPath = env["SWIFT_LLVM_BINDINGS_PATH_TO_LLVM_HEADERS"] else {
+        print("please pass an environment variable to swift-package: " +
+              "SWIFT_LLVM_BINDINGS_PATH_TO_LLVM_HEADERS " +
+              "(e.g. swift/llvm-project/llvm/include)")
         return nil
     }
     let llvmModuleMapPath = "\(llvmHeaderPath)/llvm/module.modulemap"
     guard let llvmGeneratedHeaderPath = env["SWIFT_LLVM_BINDINGS_PATH_TO_LLVM_GENERATED_HEADERS"] else {
+        print("please pass an environment variable to swift-package: " +
+              "SWIFT_LLVM_BINDINGS_PATH_TO_LLVM_GENERATED_HEADERS " +
+              "(e.g. swift/build/Ninja-DebugAssert/llvm-macosx-arm64/include)")
         return nil
     }
 


### PR DESCRIPTION
Having `fatalError` in the package manifest breaks package resolution in Xcode when these environment variables are not present. Even if the project won't build without them with SwiftPM, package resolution should still be possible.