### PR TITLE
[build] Prevent CMake from de-duplicating compiler options

### DIFF
--- a/Sources/LLVM/CMakeLists.txt
+++ b/Sources/LLVM/CMakeLists.txt
@@ -2,7 +2,7 @@ add_library(LLVM_Utils
     LLVM_Utils.swift)
 target_compile_options(LLVM_Utils PUBLIC
     "-emit-module"
-    "-Xcc" "-std=c++17"
+    "SHELL:-Xcc -std=c++17"
     "-cxx-interoperability-mode=default")
 target_include_directories(LLVM_Utils PUBLIC
     "${LLVM_MAIN_INCLUDE_DIR}"


### PR DESCRIPTION
`-Xcc` can occur several times in the list of compiler options, this tells CMake to not try to merge multiple `-Xcc` args into one.