### PR TITLE
[LLVM] Add API Notes for LLVM_Utils

### DIFF
--- a/Sources/LLVM/CMakeLists.txt
+++ b/Sources/LLVM/CMakeLists.txt
@@ -3,6 +3,9 @@ add_library(LLVM_Utils
 target_compile_options(LLVM_Utils PUBLIC
     "-emit-module"
     "SHELL:-Xcc -std=c++17"
+    "SHELL:-Xcc -fapinotes"
+    "SHELL:-Xcc -fapinotes-modules"
+    "SHELL:-Xcc -iapinotes-modules -Xcc ${CMAKE_CURRENT_SOURCE_DIR}"
     "-cxx-interoperability-mode=default")
 target_include_directories(LLVM_Utils PUBLIC
     "${LLVM_MAIN_INCLUDE_DIR}"
@@ -10,3 +13,5 @@ target_include_directories(LLVM_Utils PUBLIC
 install(TARGETS LLVM_Utils
     ARCHIVE DESTINATION lib
     LIBRARY DESTINATION lib)
+install(FILES LLVM_Utils.apinotes
+    DESTINATION include/apinotes)

--- a/Sources/LLVM/LLVM_Utils.apinotes
+++ b/Sources/LLVM/LLVM_Utils.apinotes
@@ -1,0 +1,8 @@
+Name: LLVM_Utils
+Namespaces:
+- Name: llvm
+  Tags:
+  - Name: LLVMContext
+    SwiftImportAs: reference
+    SwiftRetainOp: immortal
+    SwiftReleaseOp: immortal


### PR DESCRIPTION
The apinotes file will be used to apply clang attributes to LLVM headers without modifying the actual headers.