### PR TITLE
[Clang] Add API Notes for Clang_AST

### DIFF
--- a/Sources/Clang/CMakeLists.txt
+++ b/Sources/Clang/CMakeLists.txt
@@ -1,0 +1,2 @@
+install(FILES Clang_AST.apinotes
+    DESTINATION include/apinotes)

--- a/Sources/Clang/Clang_AST.apinotes
+++ b/Sources/Clang/Clang_AST.apinotes
@@ -1,0 +1,8 @@
+Name: Clang_AST
+Namespaces:
+- Name: clang
+  Tags:
+  - Name: Decl
+    SwiftImportAs: reference
+    SwiftRetainOp: immortal
+    SwiftReleaseOp: immortal


### PR DESCRIPTION
This makes sure Swift is importing `clang::Decl` and its transitive derived types as reference types (i.e. Swift classes).