### PR TITLE
Fix `LLVM_Utils.apinotes` unhandled file SwiftPM warning

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -43,7 +43,7 @@ let package = Package(
     .target(
       name: "SwiftLLVM_Utils",
       path: "Sources/LLVM",
-      exclude: ["CMakeLists.txt"],
+      exclude: ["CMakeLists.txt", "LLVM_Utils.apinotes"],
       sources: ["LLVM_Utils.swift"],
       swiftSettings: getLLVMSwiftSettings()
     ),


### PR DESCRIPTION
When building with SwiftPM, irrelevant files should be marked explicitly in `Package.swift`.